### PR TITLE
JWT package fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ idna==3.4
 importlib-metadata==6.0.0
 itsdangerous==2.1.2
 Jinja2==3.1.2
-jwt==1.3.1
 macholib==1.15.2
 MarkupSafe==2.1.1
 pathlib==1.0.1


### PR DESCRIPTION
Hi from San Diego! 

Found build error when trying to run the validator method: encode() does not exist. 

Looked into the requirements.txt file and found conflicting packages jwt and PyJWT both listed. 

Removing the `jwt` package because it clashes with `PyJWT`. Both packages use the same import name (`import jwt`), but only `PyJWT` includes the `encode()` that is used by validator.py. Keeping `jwt` installed leads to the environment loading the wrong library. Uninstalling `jwt` (removing it from installation requirements) ensures the code references the correct `PyJWT` library for using `encode()`. 

- Nick 